### PR TITLE
Rename macro prefix from `@` to `the`

### DIFF
--- a/frontmatter/titlepage.tex
+++ b/frontmatter/titlepage.tex
@@ -5,7 +5,6 @@
 
 \newcommand{\oneLineTitle}{\thetitle}
 \newcommand{\multiLineTitle}[1]{\thetitle}
-\makeatletter
 
 % COVER PAGE
 \begin{titlepage}
@@ -68,7 +67,7 @@ Gothenburg, Sweden \the\year
 	\textsc{\large Master's thesis \the\year}\\[4cm]		% Report number is currently not in use
 	\textbf{\Large \multiLineTitle{0.2cm}} \\[1cm]
 	{\large \oneLineSubtitle}\\[1cm]
-	{\large \@author}
+	{\large \theauthor}
 
 	\vfill
 	% Logotype on titlepage
@@ -79,7 +78,7 @@ Gothenburg, Sweden \the\year
 	\end{figure}	\vspace{5mm}
 
 	Department of Computer Science and Engineering\\
-	\emph{Division of \@division}\\
+	\emph{Division of \thedivision}\\
 	%Name of research group (if applicable)\\
 	\textsc{Chalmers University of Technology} \\
 	\textsc{University of Gothenburg} \\
@@ -93,22 +92,22 @@ Gothenburg, Sweden \the\year
 \vspace*{4.5cm}
 \noindent \oneLineTitle\\
 \oneLineSubtitle\\
-\@author
+\theauthor
 
 \vspace{1cm}
 
-\copyright ~ \@author, \the\year
+\copyright ~ \theauthor, \the\year
 
 \vspace{1em}
 
-Supervisor: \@supervisor, Department of \@departmentofsupervisor\\
-Examiner: \@examiner, Department of \@departmentofexaminer
+Supervisor: \thesupervisor, Department of \thedepartmentofsupervisor\\
+Examiner: \theexaminer, Department of \thedepartmentofexaminer
 
 \vspace{1em}
 
 Master's Thesis \the\year\\
 Department of Computer Science and Engineering\\
-Division of \@division\\
+Division of \thedivision\\
 Chalmers University of Technology and University of Gothenburg\\
 SE-412 96 Gothenburg\\
 Telephone +46 31 772 1000
@@ -124,4 +123,3 @@ Gothenburg, Sweden \the\year
 
 %% Restore the indentation once done with the title page.
 \setlength{\parindent}{1.5em}
-\makeatother

--- a/settings.tex
+++ b/settings.tex
@@ -28,31 +28,28 @@
 \usepackage{datetime} %date formatting tools
 
 \makeatletter
-\def\supervisor#1{\gdef\@supervisor{#1}}
-\def\@supervisor{\@latex@warning@no@line{No \noexpand\supervisor given}}
+\def\supervisor#1{\gdef\thesupervisor{#1}}
+\def\thesupervisor{\@latex@warning@no@line{No \noexpand\supervisor given}}
 
-\def\examiner#1{\gdef\@examiner{#1}}
-\def\@examiner{\@latex@warning@no@line{No \noexpand\examiner given}}
+\def\examiner#1{\gdef\theexaminer{#1}}
+\def\theexaminer{\@latex@warning@no@line{No \noexpand\examiner given}}
 
-\def\departmentofsupervisor#1{\gdef\@departmentofsupervisor{#1}}
-\def\@departmentofsupervisor{\@latex@warning@no@line{No \noexpand\departmentofsupervisor given}}
+\def\departmentofsupervisor#1{\gdef\thedepartmentofsupervisor{#1}}
+\def\thedepartmentofsupervisor{\@latex@warning@no@line{No \noexpand\departmentofsupervisor given}}
 
-\def\departmentofexaminer#1{\gdef\@departmentofexaminer{#1}}
-\def\@departmentofexaminer{\@latex@warning@no@line{No \noexpand\departmentofexaminer given}}
+\def\departmentofexaminer#1{\gdef\thedepartmentofexaminer{#1}}
+\def\thedepartmentofexaminer{\@latex@warning@no@line{No \noexpand\departmentofexaminer given}}
 
-\def\division#1{\gdef\@division{#1}}
-\def\@division{\@latex@warning@no@line{No \noexpand\division given}}
+\def\division#1{\gdef\thedivision{#1}}
+\def\thedivision{\@latex@warning@no@line{No \noexpand\division given}}
 
 \def\keywords#1{\gdef\thekeywords{#1}}
-
 \makeatother
 
 \renewenvironment{abstract}
   {\newpage
-   \makeatletter
    \noindent\thetitle{}\\
    \theauthor{}\\
-   \makeatother
    Department of Computer Science and Engineering\\
    Chalmers University of Technology and University of Gothenburg
 


### PR DESCRIPTION
This change comes from the fact that we need to change the catcode of
@ to be able to use at as a macro name ([source]).

Example of change:
- `\@division` -> `\thedivision`

[source]: https://tex.stackexchange.com/a/8353