### PR TITLE
Simplify subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Then create your, say `file.tex`, which should look like this:
 \input{template/template}
 
 \title{The Title}
+\subtitle{The subtitle, (line breaks are allowed)}
 \author{John Doe}
 
 \supervisor{Joe Bloggs}

--- a/frontmatter/titlepage.tex
+++ b/frontmatter/titlepage.tex
@@ -32,9 +32,7 @@
 
 \textbf{\Huge \multiLineTitle{0.2cm}} \\[0.5cm]
 
-{\Large \oneLineSubtitle}\\[0.5cm]
-
-%{\Large A Subtitle that can be Very Much Longer if Necessary}\\[0.5cm]
+{\Large \thesubtitle}\\[0.5cm]
 
 Master's Thesis in Computer Science and Engineering
 
@@ -66,7 +64,7 @@ Gothenburg, Sweden \the\year
 \begin{center}
 	\textsc{\large Master's thesis \the\year}\\[4cm]		% Report number is currently not in use
 	\textbf{\Large \multiLineTitle{0.2cm}} \\[1cm]
-	{\large \oneLineSubtitle}\\[1cm]
+	{\large \thesubtitle}\\[1cm]
 	{\large \theauthor}
 
 	\vfill
@@ -91,7 +89,7 @@ Gothenburg, Sweden \the\year
 \thispagestyle{plain}
 \vspace*{4.5cm}
 \noindent \oneLineTitle\\
-\oneLineSubtitle\\
+\thesubtitle\\
 \theauthor
 
 \vspace{1cm}

--- a/settings.tex
+++ b/settings.tex
@@ -28,6 +28,9 @@
 \usepackage{datetime} %date formatting tools
 
 \makeatletter
+\long\def\subtitle#1{\gdef\thesubtitle{#1}}
+\long\def\thesubtitle{\@latex@warning@no@line{No \noexpand\subtitle given}}
+
 \def\supervisor#1{\gdef\thesupervisor{#1}}
 \def\thesupervisor{\@latex@warning@no@line{No \noexpand\supervisor given}}
 

--- a/template.tex
+++ b/template.tex
@@ -1,7 +1,5 @@
 \input{template/settings}
 
-\newcommand{\oneLineSubtitle}{Subtitle}
-
 \newcommand{\maketitlepage}{
   \pagenumbering{roman}			% Roman numbering (starting with i (one)) until first main chapter
   \input{template/frontmatter/titlepage}


### PR DESCRIPTION
This commit removes the need for redefining \oneLineSubtitle and
instead makes it possible to set the subtitle with \subtitle command.

N.B. The first commit is not really part of this PR, but of #6 