### PR TITLE
Fix #12

### DIFF
--- a/frontmatter/titlepage.tex
+++ b/frontmatter/titlepage.tex
@@ -94,15 +94,16 @@ Gothenburg, Sweden \the\year
 
 \vspace{1cm}
 
-\copyright ~ \theauthor, \the\year
+\noindent \copyright ~ \theauthor, \the\year
 
 \vspace{1em}
 
-Supervisor: \thesupervisor, Department of \thedepartmentofsupervisor\\
+\noindent Supervisor: \thesupervisor, Department of \thedepartmentofsupervisor\\
 Examiner: \theexaminer, Department of \thedepartmentofexaminer
 
 \vspace{1em}
 
+\noindent
 Master's Thesis \the\year\\
 Department of Computer Science and Engineering\\
 Division of \thedivision\\
@@ -113,10 +114,9 @@ Telephone +46 31 772 1000
 \vfill
 % Caption for cover page figure if used, possibly with reference to further information
 % in the report
-Cover: Description of the picture on the cover page (if applicable)
-
-Typeset in \LaTeX \\
-% Printed by [Name of printing company]\\
+\noindent
+Cover: Description of the picture on the cover page (if applicable)\\
+Typeset in \LaTeX\\
 Gothenburg, Sweden \the\year
 
 %% Restore the indentation once done with the title page.


### PR DESCRIPTION
The formatting problems in the front matter, caused by removing `parskip`, are now fixed by putting `\noindent` in a bunch of places.