### PR TITLE
fix(ci): Use GitHub Action home variables for priming cache

### DIFF
--- a/.github/actions/tester/Dockerfile
+++ b/.github/actions/tester/Dockerfile
@@ -4,6 +4,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends poppler-utils \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
+# Set home directory to where GitHub Actions are run from
+RUN mkdir -p /github/home
+RUN /root/.cache/Tectonic/ /github/home/.cache/Tectonic/
+RUN rm -rf /root/.cache
+ENV HOME /github/home
+
 # Prime the cache to ensure that the packages required by the
 # template are downloaded and exists in Tectonic cache
 RUN mkdir -p /tmp/cache-primer


### PR DESCRIPTION
The whole reason for typesetting `cache.tex` is that we get a primed
cache, thus subsequent builds using the template should be much
faster. However, according to the [official documentation] GitHub
Actions set a custom home directory, effectively discarding our primed
cache and forcing tectonic to start from scratch.

This commit sets the HOME variable to the same directory as GitHub
Actions uses, in order to prime the same cache.

[official documentation]: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#docker-container-filesystem