### PR TITLE
Some cleaning

### DIFF
--- a/settings.tex
+++ b/settings.tex
@@ -102,7 +102,6 @@
 
 % Activate clickable links in table of contents
 \usepackage{hyperref}
-\hypersetup{colorlinks, citecolor=black, filecolor=black, linkcolor=black, urlcolor=black}
 
 
 % Define the number of section levels to be included in the t.o.c. and numbered	(3 is default)

--- a/settings.tex
+++ b/settings.tex
@@ -6,6 +6,7 @@
 \usepackage{amsmath}								% Mathematical expressions (American mathematical society)
 \usepackage{amssymb}								% Mathematical symbols (American mathematical society)
 \usepackage{amsthm}
+\usepackage[dvipsnames]{xcolor}
 \usepackage{graphicx}								% Figures
 \usepackage{titling}
 \usepackage{unicode-math}


### PR DESCRIPTION
I have done two simple things:

1. Added an explicit import of the `xcolor` package since it is implicitly imported by some package in the template and attempting re-import it with new options in my thesis is not possible as it is an "option clash". It might be convenient to add more options to the import of `xcolor`.
2. I removed the `\hypersetup`. As far as I know, this cannot be re-done either and I did not want all colours set to black. This provides the user with more freedom to customise but we should note in the `README` that the original is set to black.

This will probably require us to update the golden test.